### PR TITLE
Update !invitelink 

### DIFF
--- a/commands/invitelink.js
+++ b/commands/invitelink.js
@@ -1,5 +1,24 @@
+const Discord = require("discord.js");
 module.exports.run = async (bot, message, args) => {
-  message.channel.send("Lien d'invitation: https://discord.gg/y4vTKAR");
+
+  //Get admin and moderator roles
+  const administratorRole = message.guild.roles.find(
+    role => role.name === "Administrator"); 
+  const moderatorRole = message.guild.roles.find(
+    role => role.name === "Moderator");
+  
+
+  // Check if message's member is moderator or administrator.
+  if (message.member.roles.has(administratorRole.id) || (message.member.roles.has(moderatorRole.id))){
+      message.channel.send("Lien d'invitation: https://discord.gg/y4vTKAR");
+  } else {
+      let errorEmbed = new Discord.RichEmbed()
+      .setColor("e74c3c")
+      .setTitle("Erreur")
+      .setDescription('Vous n\'avez pas la permission d\'effectuer cette commande.')
+      .setTimestamp('*' + new Date() + '*')
+      return message.channel.send(errorEmbed);
+  }
 };
 
 module.exports.config = {


### PR DESCRIPTION
**Only staff members should be able to use `!invitelink`**
_Adding a role check and send error message if the author of the message isn't administrator or moderator._

**EDIT :** 

> This feature is not necessarily **very useful** because excluded members lose their roles. So normally, they can't talk again in the channels.